### PR TITLE
[IMPROVEMENT] Hide Continue button if no in-game progress

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { GameDOM } from "./view/game-gui"
 
 import "../assets/styles/reset.css";
 import "../assets/styles/styles.css";
+import { series } from "./model/knk";
 
 const root = document.documentElement;
 if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
@@ -17,7 +18,6 @@ const MenuDOM = (() => {
   const startButton = document.getElementById("button--start");
   const continueButton = document.getElementById("button--continue");
 
-
   const toggleHome = () => {
     homeScreen.classList.toggle("hidden");
   };
@@ -31,4 +31,8 @@ const MenuDOM = (() => {
     toggleHome();
     GameDOM.continueGame();
   });
+
+	if (series.isSeriesAtStartInLocalStorage()) {
+		continueButton.classList.toggle("hidden");
+	}
 })();

--- a/src/model/knk.ts
+++ b/src/model/knk.ts
@@ -164,6 +164,18 @@ const series = (() => {
     currentSentence = currentNovel.currentParagraph[currentNovel.sentenceIndex];
   };
 
+	const isSeriesAtStartInLocalStorage = (): boolean => {
+    const novelIndex = Number(localStorage.getItem("novelIndex"));
+    const chapterIndex = Number(localStorage.getItem("chapterIndex"));
+    const paragraphIndex = Number(localStorage.getItem("paragraphIndex"));
+
+		return (
+			novelIndex === 0 &&
+			chapterIndex === 0 &&
+			paragraphIndex === 0
+		);
+	}
+
   const checkPositionValidity = (): void => {
     if (currentNovel.sentenceIndex >= currentNovel.currentParagraph.length) {
       currentNovel.sentenceIndex = 0;
@@ -331,6 +343,7 @@ const series = (() => {
     addSave,
     removeSave,
     jumpSave,
+		isSeriesAtStartInLocalStorage,
   };
 })();
 


### PR DESCRIPTION
Adds functionality for Continue button in main menu when no progress has been made in local storage
- Added method in series object to determine if at the start in local storage
- Update MenuDOM to hide continue button when local storage at start of series 